### PR TITLE
Show where we imported the file from

### DIFF
--- a/commands/cfconfig/import.cfc
+++ b/commands/cfconfig/import.cfc
@@ -148,7 +148,7 @@ component {
 			error( e.message, e.detail ?: '' );
 		}
 		
-		print.greenLine( 'Config transferred!' );
+		print.greenLine( 'Config transferred from #fromDetails.path#!' );
 		
 		/* command( 'cfconfig transfer' )
 			.params( argumentCollection = arguments )


### PR DESCRIPTION
At the moment we dont know, in logs, which file was imported, this is especially important when it's dynamically driven or from an environment variable.