### PR TITLE
Changes to update version references, correct typos, and some other general cleanup

### DIFF
--- a/commands/cfconfig/cache/delete.cfc
+++ b/commands/cfconfig/cache/delete.cfc
@@ -18,7 +18,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string name,

--- a/commands/cfconfig/cache/list.cfc
+++ b/commands/cfconfig/cache/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive caches back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/cache/save.cfc
+++ b/commands/cfconfig/cache/save.cfc
@@ -1,7 +1,7 @@
 /**
 * Add a new cache or update an existing cache.  Existing caches will be matched based on the name.
 * 
-* You can use a the "type" parameter as a shortcut for specifying the full Java class, which may change between versions.
+* You can use a the "type" argument as a shortcut for specifying the full Java class, which may change between versions.
 * 
 * {code}
 * cfconfig cache save myCache RAM
@@ -16,8 +16,8 @@
 * cfconfig cache save name=myCache class=lucee.runtime.cache.ram.RamCache to=/path/to/server/home
 * {code}
 * 
-* If your cache provider expects custom properties, pass them as additional parameters to this
-* command prefixed with the text "custom:". This requires named parameters, of course.
+* If your cache provider expects custom properties, pass them as additional arguments to this
+* command prefixed with the text "custom:". This requires named arguments, of course.
 * 
 * {code}
 * cfconfig cache save name=myCache type=RAM custom:timeToIdleSeconds=0 custom:timeToLiveSeconds=0
@@ -42,7 +42,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string name,

--- a/commands/cfconfig/cfmapping/delete.cfc
+++ b/commands/cfconfig/cfmapping/delete.cfc
@@ -18,7 +18,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string virtual,

--- a/commands/cfconfig/cfmapping/list.cfc
+++ b/commands/cfconfig/cfmapping/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive mappings back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/cfmapping/save.cfc
+++ b/commands/cfconfig/cfmapping/save.cfc
@@ -27,7 +27,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string virtual,

--- a/commands/cfconfig/componentpath/delete.cfc
+++ b/commands/cfconfig/componentpath/delete.cfc
@@ -21,7 +21,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string name,

--- a/commands/cfconfig/componentpath/list.cfc
+++ b/commands/cfconfig/componentpath/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive Component  paths back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/componentpath/save.cfc
+++ b/commands/cfconfig/componentpath/save.cfc
@@ -25,7 +25,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string name,

--- a/commands/cfconfig/customtagpath/delete.cfc
+++ b/commands/cfconfig/customtagpath/delete.cfc
@@ -14,7 +14,7 @@ component {
 	property name='Util' inject='util@commandbox-cfconfig';
 	property name="serverService" inject="ServerService";
 	/**
-	* This will delete ALL mappings that match the supplied parameters
+	* This will delete ALL mappings that match the supplied arguments
 	*
 	* @index The CFConfig Index of the mapping
 	* @physical The physical path that the engine should search
@@ -27,7 +27,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		numeric index,

--- a/commands/cfconfig/customtagpath/list.cfc
+++ b/commands/cfconfig/customtagpath/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive custom tag paths back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/customtagpath/save.cfc
+++ b/commands/cfconfig/customtagpath/save.cfc
@@ -34,7 +34,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		string physical="",

--- a/commands/cfconfig/datasource/delete.cfc
+++ b/commands/cfconfig/datasource/delete.cfc
@@ -18,7 +18,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string name,

--- a/commands/cfconfig/datasource/list.cfc
+++ b/commands/cfconfig/datasource/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive mappings back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/datasource/save.cfc
+++ b/commands/cfconfig/datasource/save.cfc
@@ -36,13 +36,13 @@ component {
 	* @allowAlter Allow alter operations
 	* @allowStoredProcs Allow Stored proc calls
 	* @blob Enable blob
-	* @blobBuffer Number of bytes to retreive in binary fields
+	* @blobBuffer Number of bytes to retrieve in binary fields
 	* @class Java class of driver
 	* @clob Enable clob
-	* @clobBuffer Number of chars to retreive in long text fields
-	* @maintainConnections Maintain connections accross client requests
+	* @clobBuffer Number of chars to retrieve in long text fields
+	* @maintainConnections Maintain connections across client requests
 	* @sendStringParametersAsUnicode Enable High ASCII characters and Unicode for data sources configured for non-Latin characters
-	* @connectionLimit Max number of connections. -1 means unlimimted
+	* @connectionLimit Max number of connections. -1 means unlimited
 	* @connectionTimeout Connectiontimeout in minutes
 	* @connectionTimeoutInterval Number of seconds connections are checked to see if they've timed out
 	* @liveTimeout Connection timeout in minutes
@@ -88,7 +88,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	* @timezone Default timezone to set on the datasource.
 	*/
 	function run(

--- a/commands/cfconfig/debugtemplates/delete.cfc
+++ b/commands/cfconfig/debugtemplates/delete.cfc
@@ -18,7 +18,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string label,

--- a/commands/cfconfig/debugtemplates/list.cfc
+++ b/commands/cfconfig/debugtemplates/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive debug templates back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/debugtemplates/save.cfc
+++ b/commands/cfconfig/debugtemplates/save.cfc
@@ -1,7 +1,7 @@
 /**
 * Add a new Debug Template or update an existing one.  Existing debug templates will be matched based on the name.
 * 
-* You can use a the "type" parameter as a shortcut for the debug template
+* You can use a the "type" argument as a shortcut for the debug template
 * 
 * {code}
 * cfconfig debugtemplates save myDebugTemplate Modern
@@ -9,8 +9,8 @@
 * {code}
 * 
 * 
-* If your debug template expects custom properties, pass them as additional parameters to this
-* command prefixed with the text "custom:". This requires named parameters, of course.
+* If your debug template expects custom properties, pass them as additional arguments to this
+* command prefixed with the text "custom:". This requires named arguments, of course.
 * 
 * {code}
 * cfconfig debugtemplates save label=myDebugTemplate type=Modern custom:tab_Reference=Enabled custom:colorHighlight=Enable
@@ -37,7 +37,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string label,

--- a/commands/cfconfig/diff.cfc
+++ b/commands/cfconfig/diff.cfc
@@ -9,18 +9,18 @@
 * cfconfig diff from=path/to/servers1/home to=path/to/server2/home
 * {code}
 *
-* Both the "to" or the "from" parameters will default to the CommandBox server in the current working directory
-* but you need to at least specicy one of them to be different.  To easily compare the CommandBox server in your CWD
-* you can just specify one alternative location to compare with
+* Both the "to" or the "from" arguments will default to the CommandBox server in the current working directory
+* but you need to at least specify one of them to be different.  To easily compare the CommandBox server in your CWD
+* you can just specify one alternative location to compare with.
 *
 * {code:bash}
 * cfconfig diff to=path/to/.CFConfig.json
 * {code}
 *
-* CFConfig will guess the to and from format based on the files in the directory.  The toFormat and fromFormat
+* CFConfig will guess the "to" and "from" formats based on the files in the directory.  The "toFormat" and "fromFormat"
 * are only needed in case CFConfig can't guess the server formats, or is guessing incorrectly.
 *
-* By default, this command will show properties that are populated in at least one location.  (The equivilent
+* By default, this command will show properties that are populated in at least one location.  (The equivalent
 * of (toOnly, fromOnly, and bothPopulated).  You may override this to control which values you see.  If you specify more than one
 * filter, they are additive, or a logical "OR".
 *
@@ -45,8 +45,8 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @fromFormat The format to read from when "from" is a directory. Ex: LuceeServer@5
-	* @toFormat The format to read from when "to" is a directory. Ex: LuceeServer@5
+	* @fromFormat The format to read from when "from" is a directory. Ex: adobe@2025
+	* @toFormat The format to read from when "to" is a directory. Ex: luceeServer@7
 	* @fromOnly Display properties only present in the "from" location
 	* @toOnly Display properties only present in the "to" location
 	* @bothPopulated Display properties that have a value populated for both locations
@@ -271,7 +271,7 @@ component {
 	}
 
 	/**
-	* Pads value with spaces or truncates as neccessary
+	* Pads value with spaces or truncates as necessary
 	*/
 	private function printColumnValue( required string text, required number columnWidth ) {
 		if( len( text ) > columnWidth ) {

--- a/commands/cfconfig/eventgatewayconfig/list.cfc
+++ b/commands/cfconfig/eventgatewayconfig/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive mappings back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/eventgatewayconfig/save.cfc
+++ b/commands/cfconfig/eventgatewayconfig/save.cfc
@@ -22,7 +22,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/
 	function run(required string type,
 				 required string description,

--- a/commands/cfconfig/eventgatewayinstance/delete.cfc
+++ b/commands/cfconfig/eventgatewayinstance/delete.cfc
@@ -19,7 +19,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/
 	function run(
 		required string gatewayId,

--- a/commands/cfconfig/eventgatewayinstance/list.cfc
+++ b/commands/cfconfig/eventgatewayinstance/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive mappings back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/eventgatewayinstance/save.cfc
+++ b/commands/cfconfig/eventgatewayinstance/save.cfc
@@ -22,7 +22,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/
 	function run(required string gatewayId,
 				 required string type,

--- a/commands/cfconfig/eventgatewaylucee/delete.cfc
+++ b/commands/cfconfig/eventgatewaylucee/delete.cfc
@@ -19,7 +19,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/
 	function run(
 		required string gatewayId,

--- a/commands/cfconfig/eventgatewaylucee/list.cfc
+++ b/commands/cfconfig/eventgatewaylucee/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive mappings back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/eventgatewaylucee/save.cfc
+++ b/commands/cfconfig/eventgatewaylucee/save.cfc
@@ -1,5 +1,5 @@
 /**
-* Add a new lucee event gateway instance or update an existing event gateway config. Existing event gateway instance will be matched based on gateway Id.
+* Add a new Lucee event gateway instance or update an existing event gateway config. Existing event gateway instance will be matched based on gateway Id.
 * 
 * {code}
 * cfconfig eventgatewaylucee save myGateway lucee.extension.gateway.AsynchronousEvents
@@ -15,14 +15,14 @@ component {
 
 	/**
 	* @gatewayId An event gateway ID to identify the specific event gateway instance.
-	* @CFCPath Component path (dot delimieted) to the gateway CFC
-	* @ListenerCFCPath Component path (dot delimieted) to the listener CFC
+	* @CFCPath Component path (dot delimited) to the gateway CFC
+	* @ListenerCFCPath Component path (dot delimited) to the listener CFC
 	* @custom A struct of additional configuration for this gateway
 	* @startupMode The startup mode of the gateway.  Values: manual, automatic, disabled
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/
 	function run(required string gatewayID,
 					required string CFCPath,

--- a/commands/cfconfig/export.cfc
+++ b/commands/cfconfig/export.cfc
@@ -1,5 +1,5 @@
 /**
-* Export configuration from a server.  If you don't specify a to, we look for a CommandBox server using the current working
+* Export configuration from a server.  If you don't specify a "to" argument, we look for a CommandBox server using the current working
 * directory.  Only rely on this if you have a single CommandBox server running in the current directory.  
 * 
 * {code:bash}
@@ -12,11 +12,11 @@
 * For Lucee's web context, point to the folder containing the lucee-web.xml.cfm file.
 * Ex: <webroot>/WEB-INF/lucee
 * 
-* For Lucee's server context, point to be the "lucee-server" folder containing the /context/lucee-server.xml file.
+* For Lucee's server context, point to the "lucee-server" folder containing the /context/lucee-server.xml file.
 * Ex: /opt/lucee/lib/lucee-server
 *
-* For Adobe servers, point to the "cfusion" folder containing the lib/neo-runtime.xml file.
-* Ex: C:/ColdFusion11/cfusion
+* For Adobe servers, point to the "cfusion" folder (or a sibling "instance" folder name) containing the lib/neo-runtime.xml file.
+* Ex: C:/ColdFusion2025/cfusion
 *
 * For BoxLang servers, point to the BoxLang home containing the boxlang.json file.
 * Ex: C:/users/brad/.boxlang/config
@@ -24,23 +24,23 @@
 * For CommandBox servers, we'll get the engine/version out of CommandBox's metadata.  For non-CommandBox servers, you'll need to help me out by
 * specifying what kind of file format to use.
 * 
-* For the fromFormat and toFormat, use the name of the engine followed by @ and then the engine version like engine@version.  
-* For lucee, specify the web or sever context.  Valid engines are "luceeWeb", "luceeServer", and "adobe".  
-* For partial versions, the missing pieces will be interpreted as zeros.  Meaning adobe@11 is the same as adobe@11.0.0.
+* For the "fromFormat" and "toFormat" arguments, use the name of the engine followed by @ and then the engine version like engine@version.  
+* Valid engines are "luceeWeb", "luceeServer", and "adobe". Lucee 4-7 supports a server context, while Lucee 4-6 support web contexts. 
+* For partial versions, the missing pieces will be interpreted as zeros, meaning adobe@2025 is the same as adobe@2025.0.0.
 * Examples are:
-* - adobe@11.0.11
-* - luceeWeb@5
-* - luceeServer@4.5
+* - adobe@2025.0.6
+* - luceeWeb@6.2
+* - luceeServer@7
 * - boxlang@1
 * 
 * {code:bash}
-* cfconfig export to=/path/to/.CFConfig.json from=/path/to/server/home fromFormat=luceeServer@5.1
+* cfconfig export to=/path/to/.CFConfig.json from=/path/to/server/home fromFormat=luceeServer@7
 * {code}
 * 
-* The version number can be left off toFormat and fromFormat when reading or writing to a CFConfig JSON file or a CommandBox server since we already know the version.
+* The version number can be left off "toFormat" and "fromFormat" when reading or writing to a CFConfig JSON file or a CommandBox server since we already know the version.
 * If you don't specify a Lucee web or Server context, we default to server. Use a format of "luceeWeb" to switch.
 * 
-* You can customize what config settings are transferred with the includeList and excludeList params.  If at least one include pattern is provided, ONLY matching 
+* You can customize what config settings are transferred with the "includeList" and "excludeList" arguments.  If at least one include pattern is provided, ONLY matching 
 * settings will be included.  Nested keys such as datasources.myDSN or mailservers[1] can be used.  You may also use basic wildcards in your pattern.  A single *
 * will match any number of chars inside a key name.  A double ** will match any number of nested keys.
 * 
@@ -51,7 +51,7 @@
 * cfconfig export to=.CFConfig.json excludeList=**.password
 * {code}
 * 
-* Use the append parameter to merge incoming data with any data already present.  For example, if a server already has one datasource defined and you import
+* Use the "append" flag to merge incoming data with any data already present.  For example, if a server already has one datasource defined and you import
 * a JSON file with 2 more unique datasources, the --append flag will not remove the pre-existing one.
 * 
 * {code:bash}
@@ -60,7 +60,7 @@
 * 
 * If you usually replace sensitive or volatile information in a JSON export with env var expansions like ${DB_PASSWORD}, you can do this automatically my supplying one or more
 * replace mappings.  The key is a regular expression to match a key in the format of "datasources.myDSN.password" and the value is the name of the env var to use.
-* The values will be written to a .env file in the current working directory.  You can override this path with the "dotenvFile" param, or pass an empty string to disable it from being written.
+* The values will be written to a .env file in the current working directory.  You can override this path with the "dotenvFile" argument, or pass an empty string to disable it from being written.
 * 
 * {code:bash}
 * cfconfig export to=.CFConfig.json replace:datasources\.myDSN\.password=DB_PASSWORD
@@ -74,7 +74,7 @@
 * {code}
 * 
 * 
-* Any valid regex is possible for some clever replacements.  This example would create env vars such as DB_MYDSN_PORT, DB_MYDSN_HOST, and DB_MDSN_DATABASE
+* Any valid regex is possible for some clever replacements.  This example would create env vars such as DB_MYDSN_PORT, DB_MYDSN_HOST, and DB_MYDSN_DATABASE
 *
 * {code:bash}
 * cfconfig export to=.CFConfig.json replace:datasources\.(.*)\.(password|class|port|host|database)=DB_\1_\2 dotenvFile=../../settings.properties
@@ -102,8 +102,8 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to when "to" is a directory. Ex: LuceeServer@5
-	* @fromFormat The format to read from when "from" is a directory. Ex: LuceeServer@5
+	* @toFormat The format to write to when "to" is a directory. Ex: luceeServer@7
+	* @fromFormat The format to read from when "from" is a directory. Ex: adobe@2025
 	* @pauseTasks It set to true, all scheduled tasks will be saved to the "to" server in a "Paused" state
 	* @includeList List of properties to include in transfer. Use * for wildcard. i.e. mailservers,datasources.myDSN,event*
 	* @includeList.optionsUDF propertyComplete
@@ -166,7 +166,7 @@ component {
 			
 			CFConfigService.transfer(
 				from				= fromDetails.path,
-				to				= toDetails.path,
+				to					= toDetails.path,
 				fromFormat			= fromDetails.format,
 				toFormat			= toDetails.format,
 				fromVersion			= fromDetails.version,

--- a/commands/cfconfig/import.cfc
+++ b/commands/cfconfig/import.cfc
@@ -1,5 +1,5 @@
 /**
-* Import configuration to a server.  If you don't specify a to, we look for a CommandBox server using the current working
+* Import configuration to a server.  If you don't specify a "to" argument, we look for a CommandBox server using the current working
 * directory.  Only rely on this if you have a single CommandBox server running in the current directory.  
 * 
 * {code:bash}
@@ -12,11 +12,11 @@
 * For Lucee's web context, point to the folder containing the lucee-web.xml.cfm file.
 * Ex: <webroot>/WEB-INF/lucee
 * 
-* For Lucee's server context, point to be the "lucee-server" folder containing the /context/lucee-server.xml file.
+* For Lucee's server context, point to the "lucee-server" folder containing the /context/lucee-server.xml file.
 * Ex: /opt/lucee/lib/lucee-server
 *
-* For Adobe servers, point to the "cfusion" folder containing the lib/neo-runtime.xml file.
-* Ex: C:/ColdFusion11/cfusion
+* For Adobe servers, point to the "cfusion" folder (or a sibling "instance" folder name) containing the lib/neo-runtime.xml file.
+* Ex: C:/ColdFusion2025/cfusion
 *
 * For BoxLang servers, point to the BoxLang home containing the boxlang.json file.
 * Ex: C:/users/brad/.boxlang/config
@@ -24,23 +24,23 @@
 * For CommandBox servers, we'll get the engine/version out of CommandBox's metadata.  For non-CommandBox servers, you'll need to help me out by
 * specifying what kind of file format to use.
 * 
-* For the fromFormat and toFormat, use the name of the engine followed by @ and then the engine version like engine@version.  
-* For lucee, specify the web or sever context.  Valid engines are "luceeWeb", "luceeServer", and "adobe".  
-* For partial versions, the missing pieces will be interpreted as zeros.  Meaning adobe@11 is the same as adobe@11.0.0.
+* For the "fromFormat" and "toFormat" arguments, use the name of the engine followed by @ and then the engine version like engine@version.  
+* Valid engines are "luceeWeb", "luceeServer", and "adobe". Lucee 4-7 supports a server context, while Lucee 4-6 support web contexts. 
+* For partial versions, the missing pieces will be interpreted as zeros, meaning adobe@2025 is the same as adobe@2025.0.0.
 * Examples are:
-* - adobe@11.0.11
-* - luceeWeb@5
-* - luceeServer@4.5
+* - adobe@2025.0.6
+* - luceeWeb@6.2
+* - luceeServer@7
 * - boxlang@1
 * 
 * {code:bash}
-* cfconfig import from=/path/to/.CFConfig.json to=/path/to/server/home toFormat=luceeServer@5.1
+* cfconfig import from=/path/to/.CFConfig.json to=/path/to/server/home toFormat=luceeServer@7
 * {code}
 * 
-* The version number can be left off toFormat and fromFormat when reading or writing to a CFConfig JSON file or a CommandBox server since we already know the version.
+* The version number can be left off "toFormat" and "fromFormat" when reading or writing to a CFConfig JSON file or a CommandBox server since we already know the version.
 * If you don't specify a Lucee web or Server context, we default to server. Use a format of "luceeWeb" to switch.
 * 
-* You can customize what config settings are transferred with the includeList and excludeList params.  If at least one include pattern is provided, ONLY matching 
+* You can customize what config settings are transferred with the "includeList" and "excludeList" arguments.  If at least one include pattern is provided, ONLY matching 
 * settings will be included.  Nested keys such as datasources.myDSN or mailservers[1] can be used.  You may also use basic wildcards in your pattern.  A single *
 * will match any number of chars inside a key name.  A double ** will match any number of nested keys.
 * 
@@ -51,7 +51,7 @@
 * cfconfig import from=.CFConfig.json excludeList=**.password
 * {code}
 * 
-* Use the append parameter to merge incoming data with any data already present.  For example, if a server already has one datasource defined and you import
+* Use the "append" flag to merge incoming data with any data already present.  For example, if a server already has one datasource defined and you import
 * a JSON file with 2 more unique datasources, the --append flag will not remove the pre-existing one.
 * 
 * {code:bash}
@@ -69,8 +69,8 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @fromFormat The format to read from when "from" is a directory. Ex: LuceeServer@5
-	* @toFormat The format to write to when "to" is a directory. Ex: LuceeServer@5
+	* @fromFormat The format to read from when "from" is a directory. Ex: luceeServer@7
+	* @toFormat The format to write to when "to" is a directory. Ex: adobe@2025
 	* @pauseTasks It set to true, all scheduled tasks will be saved to the "to" server in a "Paused" state
 	* @includeList List of properties to include in transfer. Use * for wildcard. i.e. mailservers,datasources.myDSN,event*
 	* @includeList.optionsUDF propertyComplete

--- a/commands/cfconfig/logger/delete.cfc
+++ b/commands/cfconfig/logger/delete.cfc
@@ -18,7 +18,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string name,

--- a/commands/cfconfig/logger/list.cfc
+++ b/commands/cfconfig/logger/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive loggers back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/logger/save.cfc
+++ b/commands/cfconfig/logger/save.cfc
@@ -24,7 +24,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string name,

--- a/commands/cfconfig/mailserver/delete.cfc
+++ b/commands/cfconfig/mailserver/delete.cfc
@@ -18,7 +18,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string smtp,

--- a/commands/cfconfig/mailserver/list.cfc
+++ b/commands/cfconfig/mailserver/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive mappings back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/mailserver/save.cfc
+++ b/commands/cfconfig/mailserver/save.cfc
@@ -15,7 +15,7 @@ component {
 	property name="serverService" inject="ServerService";
 	
 	/**
-	* @idleTimout Idle timeout in seconds
+	* @idleTimeout Idle timeout in seconds
 	* @lifeTimeout Overall timeout in seconds
 	* @password Plain text password for mail server
 	* @port Port for mail server
@@ -26,7 +26,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		string smtp,

--- a/commands/cfconfig/pdfservice/delete.cfc
+++ b/commands/cfconfig/pdfservice/delete.cfc
@@ -18,7 +18,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string name,

--- a/commands/cfconfig/pdfservice/list.cfc
+++ b/commands/cfconfig/pdfservice/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive PDF services back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/pdfservice/save.cfc
+++ b/commands/cfconfig/pdfservice/save.cfc
@@ -25,7 +25,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/	
 	function run(
 		required string name,

--- a/commands/cfconfig/set.cfc
+++ b/commands/cfconfig/set.cfc
@@ -14,7 +14,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	* @append.hint Append struct/array setting, instead of overwriting.
 	*/	
 	function run( 

--- a/commands/cfconfig/show.cfc
+++ b/commands/cfconfig/show.cfc
@@ -15,7 +15,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	*/	
 	function run( 
 		string property,

--- a/commands/cfconfig/task/delete.cfc
+++ b/commands/cfconfig/task/delete.cfc
@@ -19,7 +19,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/
 	function run(
 		required string task,

--- a/commands/cfconfig/task/list.cfc
+++ b/commands/cfconfig/task/list.cfc
@@ -25,7 +25,7 @@ component {
 	* @from CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @from.optionsFileComplete true
 	* @from.optionsUDF serverNameComplete
-	* @fromFormat The format to read from. Ex: LuceeServer@5
+	* @fromFormat The format to read from. Ex: LuceeServer@7
 	* @JSON Set to try to receive mappings back as a parsable JSON object
 	*/
 	function run(

--- a/commands/cfconfig/task/save.cfc
+++ b/commands/cfconfig/task/save.cfc
@@ -2,9 +2,9 @@
 * Add a new scheduled task or update an existing scheduled task.  Existing scheduled tasks will be matched based on the host name.
 *
 * {code}
-* cfconfig task save myTask http://www.google.com Once 4/13/2018 "5:00 PM"
-* cfconfig task save task=myTask url=http://www.google.com interval=Once startDate=4/13/2018 startTime="5:00 PM" to=serverName
-* cfconfig task save task=myTask url=http://www.google.com interval=Once startDate=4/13/2018 startTime="5:00 PM" to=/path/to/server/home
+* cfconfig task save myTask http://www.google.com Once 4/2/2026 "5:00 PM"
+* cfconfig task save task=myTask url=http://www.google.com interval=Once startDate=4/2/2026 startTime="5:00 PM" to=serverName
+* cfconfig task save task=myTask url=http://www.google.com interval=Once startDate=4/2/2026 startTime="5:00 PM" to=/path/to/server/home
 * {code}
 *
 */
@@ -29,7 +29,7 @@ component {
 	* @httpPort The port for the main task URL
 	* @httpProxyPort The port for the proxy server
 	* @interval The type of schedule. Once, Weekly, Daily, Monthly, an integer containing the number of seconds between runs
-	* @misfire What to do in case of a misfire.  Ignore, FireNow, invokeHander (Adobe only)
+	* @misfire What to do in case of a misfire.  Ignore, FireNow, invokeHandler (Adobe only)
 	* @oncomplete Comma-separated list of chained tasks to be run after the completion of the current task (task1:group1,task2:group2...) (Adobe only)
 	* @onexception Specify what to do if a task results in error. Ignore, Pause, ReFire, InvokeHandler (Adobe only)
 	* @overwrite Overwrite the log file? (Adobe only)
@@ -44,7 +44,7 @@ component {
 	* @resolveurl When saving output of task to file, Resolve internal URLs so that links remain intact.
 	* @retrycount The number of reattempts if the task results in an error. (Adobe only)
 	* @startDate The date to start executing the task
-	* @startTime The date to end excuting the task
+	* @startTime The date to end executing the task
 	* @status The current status of the task.  Running, Paused
 	* @username Basic auth username to use when hitting URL
 	* @autoDelete (Lucee only)
@@ -53,7 +53,7 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @toFormat The format to write to. Ex: LuceeServer@5
+	* @toFormat The format to write to. Ex: LuceeServer@7
 	*/
 	function run(
 		required string task,

--- a/commands/cfconfig/transfer.cfc
+++ b/commands/cfconfig/transfer.cfc
@@ -1,6 +1,6 @@
 /**
-* Transfer configuration from one location/server to another.  If you don't specify a from or to, we look for a CommandBox server using the current working
-* directory.  Only rely on this if you have a single CommandBox server running in the current directory.  You must specify at least a from or a to.
+* Transfer configuration from one location/server to another.  If you don't specify a "from" or "to" argument, we look for a CommandBox server using the current working
+* directory.  Only rely on this if you have a single CommandBox server running in the current directory.  You must specify at least a "from" or a "to".
 * 
 * {code:bash}
 * cfconfig transfer from=servername to=anotherServername
@@ -12,11 +12,11 @@
 * For Lucee's web context, point to the folder containing the lucee-web.xml.cfm file.
 * Ex: <webroot>/WEB-INF/lucee
 * 
-* For Lucee's server context, point to be the "lucee-server" folder containing the /context/lucee-server.xml file.
+* For Lucee's server context, point to the "lucee-server" folder containing the /context/lucee-server.xml file.
 * Ex: /opt/lucee/lib/lucee-server
 *
-* For Adobe servers, point to the "cfusion" folder containing the lib/neo-runtime.xml file.
-* Ex: C:/ColdFusion11/cfusion
+* For Adobe servers, point to the "cfusion" folder (or a sibling "instance" folder name) containing the lib/neo-runtime.xml file.
+* Ex: C:/ColdFusion2025/cfusion
 *
 * For BoxLang servers, point to the BoxLang home containing the boxlang.json file.
 * Ex: C:/users/brad/.boxlang/config
@@ -27,7 +27,7 @@
 * cfconfig transfer to=/path/to/server/home
 * {code}
 *
-* When transfering configuration to or from a generic CFConfig JSON file, use the full path to the JSON file:
+* When transferring configuration to or from a generic CFConfig JSON file, use the full path to the JSON file:
 * 
 * {code:bash}
 * cfconfig transfer from=/path/to/.CFConfig.json
@@ -37,23 +37,23 @@
 * For CommandBox servers, we'll get the engine/version out of CommandBox's metadata.  For non-CommandBox servers, you'll need to help me out by
 * specifying what kind of file format to use.
 * 
-* For the fromFormat and toFormat, use the name of the engine followed by @ and then the engine version like engine@version.  
-* For lucee, specify the web or sever context.  Valid engines are "luceeWeb", "luceeServer", and "adobe".  
-* For partial versions, the missing pieces will be interpreted as zeros.  Meaning adobe@11 is the same as adobe@11.0.0.
+* For the "fromFormat" and "toFormat" arguments, use the name of the engine followed by @ and then the engine version like engine@version.  
+* Valid engines are "luceeWeb", "luceeServer", and "adobe". Lucee 4-7 supports a server context, while Lucee 4-6 support web contexts. 
+* For partial versions, the missing pieces will be interpreted as zeros, meaning adobe@2025 is the same as adobe@2025.0.0.
 * Examples are:
-* - adobe@11.0.11
-* - luceeWeb@5
-* - luceeServer@4.5
+* - adobe@2025.0.6
+* - luceeWeb@6.2
+* - luceeServer@7
 * - boxlang@1
 * 
 * {code:bash}
-* cfconfig transfer from=/path/to/.CFConfig.json to=/path/to/server/home toFormat=luceeServer@5.1
+* cfconfig transfer from=/path/to/.CFConfig.json to=/path/to/server/home toFormat=luceeServer@7
 * {code}
 * 
-* The version number can be left off toFormat and fromFormat when reading or writing to a CFConfig JSON file or a CommandBox server since we already know the version.
+* The version number can be left off "toFormat" and "fromFormat" when reading or writing to a CFConfig JSON file or a CommandBox server since we already know the version.
 * If you don't specify a Lucee web or Server context, we default to server. Use a format of "luceeWeb" to switch.
 * 
-* You can customize what config settings are transferred with the includeList and excludeList params.  If at least one include pattern is provided, ONLY matching 
+* You can customize what config settings are transferred with the "includeList" and "excludeList" arguments.  If at least one include pattern is provided, ONLY matching 
 * settings will be included.  Nested keys such as datasources.myDSN or mailservers[1] can be used.  You may also use basic wildcards in your pattern.  A single *
 * will match any number of chars inside a key name.  A double ** will match any number of nested keys.
 * 
@@ -64,33 +64,33 @@
 * cfconfig export to=.CFConfig.json excludeList=**.password
 * {code}
 * 
-* Use the append parameter to merge incoming data with any data already present.  For example, if a server already has one datasource defined and you import
+* Use the "append" flag to merge incoming data with any data already present.  For example, if a server already has one datasource defined and you import
 * a JSON file with 2 more unique datasources, the --append flag will not remove the pre-existing one.
 * 
 * {code:bash}
-* cfconfig tranfser to=.CFConfig.json includeList=datasources --append
+* cfconfig transfer to=.CFConfig.json includeList=datasources --append
 * {code}
 * 
 * If you usually replace sensitive or volatile information in a JSON export with env var expansions like ${DB_PASSWORD}, you can do this automatically my supplying one or more
 * replace mappings.  The key is a regular expression to match a key in the format of "datasources.myDSN.password" and the value is the name of the env var to use.
-* The values will be written to a .env file in the current working directory.  You can override this path with the "dotenvFile" param, or pass an empty string to disable it from being written.
+* The values will be written to a .env file in the current working directory.  You can override this path with the "dotenvFile" argument, or pass an empty string to disable it from being written.
 * 
 * {code:bash}
-* cfconfig tranfser to=.CFConfig.json replace:datasources\.myDSN\.password=DB_PASSWORD
+* cfconfig transfer to=.CFConfig.json replace:datasources\.myDSN\.password=DB_PASSWORD
 * {code}
 * 
 * As the value is a regular expression, you can use backreferences like \1 in your env var to make them dynamic.  
 * This example would create env vars such as DB_MYDSN_PASSWORD where MYDSN is your actual datasource name.
 *
 * {code:bash}
-* cfconfig tranfser to=.CFConfig.json replace:datasources\.(.*)\.password=DB_\1_PASSWORD
+* cfconfig transfer to=.CFConfig.json replace:datasources\.(.*)\.password=DB_\1_PASSWORD
 * {code}
 * 
 * 
-* Any valid regex is possible for some clever replacements.  This example would create env vars such as DB_MYDSN_PORT, DB_MYDSN_HOST, and DB_MDSN_DATABASE
+* Any valid regex is possible for some clever replacements.  This example would create env vars such as DB_MYDSN_PORT, DB_MYDSN_HOST, and DB_MYDSN_DATABASE
 *
 * {code:bash}
-* cfconfig tranfser to=.CFConfig.json replace:datasources\.(.*)\.(password|class|port|host|database)=DB_\1_\2 dotenvFile=../../settings.properties
+* cfconfig transfer to=.CFConfig.json replace:datasources\.(.*)\.(password|class|port|host|database)=DB_\1_\2 dotenvFile=../../settings.properties
 * {code}
 *
 * To avoid having to pass these replacements every time you transfer your config, you can set then as a global setting for the commandbox-cfconfig module.
@@ -119,8 +119,8 @@ component {
 	* @to CommandBox server name, server home path, or CFConfig JSON file. Defaults to CommandBox server in CWD.
 	* @to.optionsFileComplete true
 	* @to.optionsUDF serverNameComplete
-	* @fromFormat The format to read from when "from" is a directory. Ex: LuceeServer@5
-	* @toFormat The format to write to when "to" is a directory. Ex: LuceeServer@5
+	* @fromFormat The format to read from when "from" is a directory. Ex: adobe@2025
+	* @toFormat The format to write to when "to" is a directory. Ex: luceeServer@7
 	* @pauseTasks It set to true, all scheduled tasks will be saved to the "to" server in a "Paused" state
 	* @includeList List of properties to include in transfer. Use * for wildcard. i.e. mailservers,datasources.myDSN,event*
 	* @includeList.optionsUDF propertyComplete
@@ -184,7 +184,7 @@ component {
 			
 			CFConfigService.transfer(
 				from				= fromDetails.path,
-				to				= toDetails.path,
+				to					= toDetails.path,
 				fromFormat			= fromDetails.format,
 				toFormat			= toDetails.format,
 				fromVersion			= fromDetails.version,

--- a/models/Util.cfc
+++ b/models/Util.cfc
@@ -16,7 +16,7 @@ component singleton {
 	/**
 	* @from The to or from value specified to the command
 	* @format The given format of the to or from value
-	* @fromToName The desinator "to" or "from" to know what we're looking up for better error messages
+	* @fromToName The designator "to" or "from" to know what we're looking up for better error messages
 	*/
 	function resolveServerDetails( string from, string format, string fromToName='', boolean preferWeb=false ) {
 		var results = {
@@ -121,7 +121,7 @@ component singleton {
 
 			if( !results.path.len() ) {
 				throw(
-					message="CFConfig couldn't find the CF Home for [#fromToName#] CommandBox server [#serverInfo.name#]. #( !format.len() ? 'Please give me a hint with the format parameter' : '' )#",
+					message="CFConfig couldn't find the CF Home for [#fromToName#] CommandBox server [#serverInfo.name#]. #( !format.len() ? 'Please give me a hint with the format argument' : '' )#",
 					detail="#( engineName contains 'lucee' ? 'This is a Lucee server, so you need to tell me if you want the web or server context. (luceeWeb/luceeServer format)' : '' )#",
 					type="cfconfigException"
 				);
@@ -144,12 +144,12 @@ component singleton {
 			results.format = guessedFormat.format;
 			results.version = guessedFormat.version;
 
-			// Overrid with user-provided format
+			// Override with user-provided format
 			if( format.len() ) {
 				results.format = listFirst( format, '@' );
 			}
 
-			// Overrid with user-provided version
+			// Override with user-provided version
 			if( format.listLen( '@' ) > 1 ) {
 				results.version = listLast( format, '@' );
 			}

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ This library is a CommandBox module that provides a CLI interface sitting on top
 
 * Export config from a server as a backup
 * Import config to a server to speed/automate setup
-* Copy config from one server to another.  Servers could be different engines-- i.e. copy config from Adobe CF11 to Lucee 5.
+* Copy config from one server to another.  Servers could be different engines-- i.e. copy config from Adobe CF2025 to Lucee 7
 * Merge config from multiple servers together. Ex: combine several Lucee web contexts into a single config (mappings, datasources, etc)
 * Facilitate the external management of any server's settings
 * Compare settings between two sources
@@ -63,9 +63,9 @@ Each command allows you to specify a `from` and/or a `to` location, based on wha
 
 When interacting with CommandBox servers, we try really hard to figure out the type and version of server you're dealing with.  When you simply point to a folder on the hard drive that contains a server home, you'll need to tell us what format you would like the config read or written as.  When writing config, the target directory doesn't need to exist.  We'll create everything for you so you can `import` configuration before you even start the server the first time.  Proper formats look like one of these:
 
-* **adobe@11** - Read/write from an Adobe server, version 11.x
-* **luceeServer@4.5** - Read/write from the Lucee server context, expecting version 4.5.x
-* **luceeWeb@5** - Read/write from the Lucee web context, expecting version 5.x.x
+* **adobe@2025** - Read/write from an Adobe ColdFusion server, version 2025.x
+* **luceeServer@7** - Read/write from the Lucee server context, expecting version 7.x
+* **luceeWeb@6** - Read/write from the Lucee web context, expecting version 6.x
 
 ### Export config from a server
 
@@ -79,14 +79,14 @@ cfconfig export myConfig.json /path/to/server/install/home
 ```bash
 cfconfig import myConfig.json
 cfconfig import myConfig.json serverName
-cfconfig import from=myConfig.json to=/path/to/server/install/home toFormat=luceeWeb@4.5
+cfconfig import from=myConfig.json to=/path/to/server/install/home toFormat=luceeServer@7
 ```
 
 ### Transfer config between two servers
 Note the two servers do not need to be the same kind.  CFConfig will translate the config for you.
 ```bash
 cfconfig transfer server1 server2
-cfconfig transfer from=/path/to/server1/install/home to=/path/to/server2/install/home fromFormat=adobe@11 toFormat=luceeServer@5
+cfconfig transfer from=/path/to/server1/install/home to=/path/to/server2/install/home fromFormat=adobe@2025 toFormat=luceeServer@7
 ```
 
 ### View all configuration
@@ -100,7 +100,7 @@ cfconfig show from="/path/to/server/install/home"
 ```bash
 cfconfig show requestTimeout
 cfconfig show requestTimeout serverName
-cfconfig show requestTimeout /path/to/server/install/home adobe@11
+cfconfig show requestTimeout /path/to/server/install/home adobe@2025
 ```
 
 ### Diff settings between two servers.
@@ -119,12 +119,12 @@ cfconfig diff to=serverName --valuesDiffer --toOnly --fromOnly
 ```
 
 ### Set a configuration setting
-Note, this command requires named parameters.
+Note, this command requires named arguments.
 
 ```bash
 cfconfig set adminPassword=commandbox
 cfconfig set adminPassword=commandbox to=serverName
-cfconfig set adminPassword=commandbox to=/path/to/server/install/home toFormat=adobe@11
+cfconfig set adminPassword=commandbox to=/path/to/server/install/home toFormat=adobe@2025
 ```
 
 You can actually use `cfconfig set` to manage the static contents of a JSON export. The JSON file is, after all, just another location you can read from or write to.
@@ -176,15 +176,15 @@ cfconfig customtagpath delete /foo
 ```
 
 ### Manage Event Gateway Configurations
-There are three commands to manage Event Gateway onfig.
+There are three commands to manage Event Gateway config.
 ```bash
 cfconfig eventgatewayconfig list
 cfconfig eventgatewayconfig save myType "description of gateway" "java.class" 30 true
 cfconfig eventgatewayconfig delete myType
 ```
 
-### Manage Event Gatway Instances
-There are three commands to manage Event Gatway Instances.
+### Manage Event Gateway Instances
+There are three commands to manage Event Gateway Instances.
 ```bash
 cfconfig eventgatewayinstance list
 cfconfig eventgatewayinstance save myInstanceId CFML "/path1/some.cfc,/path2/code.cfc"
@@ -203,7 +203,7 @@ cfconfig logger delete application
 There are three commands to manage Scheduled Tasks.
 ```bash
 cfconfig task list
-cfconfig task save myTask http://www.google.com Once 4/13/2018 "5:00 PM"
+cfconfig task save myTask http://www.google.com Once 4/2/2026 "5:00 PM"
 cfconfig task delete myTask myGroup
 ```
 
@@ -217,7 +217,7 @@ And remember, this project is just the CLI component. If you'd like to build a c
 
 ## Contributing
 
-To run the changes you have implemnted in the `config` project via commandbox you need to follow the following steps:
+To run the changes you have implemented in the `config` project via commandbox you need to follow the following steps:
 
 - Uninstall your local `commandbox-cfconfig` package via:
 


### PR DESCRIPTION
Discussed changes with Brad privately before creating PR:
- changed old references (like examples with Lucee 4 or 5 to use Lucee 6 or 7--and of course I was careful to not use luceeweb with 7, which is why some refer to luceeweb as 6, etc). Again, in about half the files the ONLY change was a reference of lucee@5 to lucee@7. Critical? no. But I figured "let's rip off the bandaid", and it doubled the number of files changed
- spell checked (only a couple dozen or so corrections. And I tried to be careful not to change any api argument names or code variable names). I didn't save the spellcheck "added words" file  into the config of the project, but I could do that if you all wanted me to
- changed some date references from 2018 to 2026 (in the "task" examples for setting sched tasks. Not critical of course, but changed it while I noticed it as part of "updating" things)
- corrected some casing of coldfusion or lucee, when clearly in text referring to them as product names not argument values
- corrected the lack of quoting around some arguments (so a reference to toformat became "toformat"), but of course I was careful to only do it in text shown to users, rather than in code, args to methods, etc.
- changed several places where "param" or "parameter" was used, to say "argument", especially for text shown to users (which was more consistent with most other uses for naming args to the commands). But I didn't change it in code, where parameter might be used for args into a CFC
- along the same lines, corrected a couple places "param" was used where "flag" should have been, regarding names of "--name" flags supported, again for the sake of consistency (not as a foolish consistency but simply "while I was looking at "param" for the point above, anyway)
- corrected a couple of places where the discussion of identifying cf engine locations said simply "For Adobe servers, point to the "cfusion" folder containing the lib/neo-runtime.xml file." to instead say, "For Adobe servers, point to the "cfusion" folder (or a sibling "instance" folder name) containing the lib/neo-runtime.xml file." 